### PR TITLE
feat: add product submenu

### DIFF
--- a/ecommerce.html
+++ b/ecommerce.html
@@ -162,7 +162,19 @@
     <li>Notify</li>
   </ul>
 </li>
-        <li>📦 <span class="txt">Products</span></li>
+        <li class="has-sub">
+  <div class="menu-head">📦 <span class="txt">Products</span> <span class="caret">▾</span></div>
+  <ul class="submenu" aria-label="Products">
+    <li>Product Manage</li>
+    <li>Categories</li>
+    <li>Subcategories</li>
+    <li>Childcategories</li>
+    <li>Brands</li>
+    <li>Colors</li>
+    <li>Sizes</li>
+    <li>Price Edit</li>
+  </ul>
+</li>
         <li>⭐ <span class="txt">Reviews</span></li>
         <li>📄 <span class="txt">Landing Page</span></li>
         <li>👥 <span class="txt">Users</span></li>
@@ -361,13 +373,16 @@
 
     submit.addEventListener('click', applyFilters);
     [keyword, assignUser, start, end].forEach(el => el.addEventListener('change', applyFilters));
-    reset.addEventListener('click', () => { keyword.value=''; assignUser.value=''; start.value=''; end.value=''; document.querySelectorAll('.menu .has-sub .menu-head').forEach(head=>{
-  head.addEventListener('click', ()=>{
-    const li = head.closest('.has-sub');
-    li.classList.toggle('open');
-  });
-});
-applyFilters(); });
+    document.querySelectorAll('.menu .has-sub .menu-head').forEach(head => {
+      head.addEventListener('click', () => {
+        const li = head.closest('.has-sub');
+        li.classList.toggle('open');
+      });
+    });
+    reset.addEventListener('click', () => {
+      keyword.value=''; assignUser.value=''; start.value=''; end.value='';
+      applyFilters();
+    });
 
     document.getElementById('btnPrint').addEventListener('click', () => window.print());
 


### PR DESCRIPTION
## Summary
- add collapsible Products menu with product management links
- enable submenu toggling on all menus

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689cb1c2edbc83278432b9c5cabfc3f8