### PR TITLE
Add Landing Page submenu

### DIFF
--- a/ecommerce.html
+++ b/ecommerce.html
@@ -164,7 +164,13 @@
 </li>
         <li>📦 <span class="txt">Products</span></li>
         <li>⭐ <span class="txt">Reviews</span></li>
-        <li>📄 <span class="txt">Landing Page</span></li>
+        <li class="has-sub open">
+          <div class="menu-head">📄 <span class="txt">Landing Page</span> <span class="caret">▾</span></div>
+          <ul class="submenu" aria-label="Landing Page">
+            <li>Create</li>
+            <li>Campaign</li>
+          </ul>
+        </li>
         <li>👥 <span class="txt">Users</span></li>
         <li>⚙️ <span class="txt">Site Settings</span></li>
         <li>🔗 <span class="txt">API Integration</span></li>
@@ -361,13 +367,20 @@
 
     submit.addEventListener('click', applyFilters);
     [keyword, assignUser, start, end].forEach(el => el.addEventListener('change', applyFilters));
-    reset.addEventListener('click', () => { keyword.value=''; assignUser.value=''; start.value=''; end.value=''; document.querySelectorAll('.menu .has-sub .menu-head').forEach(head=>{
-  head.addEventListener('click', ()=>{
-    const li = head.closest('.has-sub');
-    li.classList.toggle('open');
-  });
-});
-applyFilters(); });
+    document.querySelectorAll('.menu .has-sub .menu-head').forEach(head => {
+      head.addEventListener('click', () => {
+        const li = head.closest('.has-sub');
+        li.classList.toggle('open');
+      });
+    });
+
+    reset.addEventListener('click', () => {
+      keyword.value = '';
+      assignUser.value = '';
+      start.value = '';
+      end.value = '';
+      applyFilters();
+    });
 
     document.getElementById('btnPrint').addEventListener('click', () => window.print());
 


### PR DESCRIPTION
## Summary
- add Landing Page dropdown with Create and Campaign items
- wire up menu toggle handler and simplify reset

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689cb214e5e083278d70a23b0a070f09