### PR TITLE
feat: add site setting submenu

### DIFF
--- a/ecommerce.html
+++ b/ecommerce.html
@@ -166,7 +166,18 @@
         <li>⭐ <span class="txt">Reviews</span></li>
         <li>📄 <span class="txt">Landing Page</span></li>
         <li>👥 <span class="txt">Users</span></li>
-        <li>⚙️ <span class="txt">Site Settings</span></li>
+        <li class="has-sub">
+          <div class="menu-head">⚙️ <span class="txt">Site Setting</span> <span class="caret">▾</span></div>
+          <ul class="submenu" aria-label="Site Setting">
+            <li>General Setting</li>
+            <li>Pixels Setting</li>
+            <li>Social Media</li>
+            <li>Contact</li>
+            <li>Create Page</li>
+            <li>Shipping Charge</li>
+            <li>Order Status</li>
+          </ul>
+        </li>
         <li>🔗 <span class="txt">API Integration</span></li>
         <li>📊 <span class="txt">G. Pixel & GTM</span></li>
         <li>🖼️ <span class="txt">Banner & Ads</span></li>
@@ -361,13 +372,14 @@
 
     submit.addEventListener('click', applyFilters);
     [keyword, assignUser, start, end].forEach(el => el.addEventListener('change', applyFilters));
-    reset.addEventListener('click', () => { keyword.value=''; assignUser.value=''; start.value=''; end.value=''; document.querySelectorAll('.menu .has-sub .menu-head').forEach(head=>{
-  head.addEventListener('click', ()=>{
-    const li = head.closest('.has-sub');
-    li.classList.toggle('open');
-  });
-});
-applyFilters(); });
+    reset.addEventListener('click', () => { keyword.value=''; assignUser.value=''; start.value=''; end.value=''; applyFilters(); });
+
+    document.querySelectorAll('.menu .has-sub .menu-head').forEach(head => {
+      head.addEventListener('click', () => {
+        const li = head.closest('.has-sub');
+        li.classList.toggle('open');
+      });
+    });
 
     document.getElementById('btnPrint').addEventListener('click', () => window.print());
 


### PR DESCRIPTION
## Summary
- add a Site Setting dropdown with multiple sub-options in sidebar
- enable submenu toggling for items with children

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689cb2674eb88327bb755316ccc70b60