### PR TITLE
Add submenu for G. Pixel and GTM

### DIFF
--- a/ecommerce.html
+++ b/ecommerce.html
@@ -168,7 +168,13 @@
         <li>👥 <span class="txt">Users</span></li>
         <li>⚙️ <span class="txt">Site Settings</span></li>
         <li>🔗 <span class="txt">API Integration</span></li>
-        <li>📊 <span class="txt">G. Pixel & GTM</span></li>
+        <li class="has-sub">
+  <div class="menu-head">📊 <span class="txt">G. Pixel & GTM</span> <span class="caret">▾</span></div>
+  <ul class="submenu" aria-label="Tag Manager">
+    <li>Tag Manager</li>
+    <li>Pixel Manage</li>
+  </ul>
+</li>
         <li>🖼️ <span class="txt">Banner & Ads</span></li>
         <li>📈 <span class="txt">Reports</span></li>
       </ul>


### PR DESCRIPTION
## Summary
- Convert the G. Pixel & GTM menu item into a dropdown with Tag Manager and Pixel Manage options.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689cb49df5208327b92ebb748ba7cc3f