### PR TITLE
Add Banner & Ads submenu

### DIFF
--- a/ecommerce.html
+++ b/ecommerce.html
@@ -168,9 +168,15 @@
         <li>👥 <span class="txt">Users</span></li>
         <li>⚙️ <span class="txt">Site Settings</span></li>
         <li>🔗 <span class="txt">API Integration</span></li>
-        <li>📊 <span class="txt">G. Pixel & GTM</span></li>
-        <li>🖼️ <span class="txt">Banner & Ads</span></li>
-        <li>📈 <span class="txt">Reports</span></li>
+          <li>📊 <span class="txt">G. Pixel & GTM</span></li>
+          <li class="has-sub">
+            <div class="menu-head">🖼️ <span class="txt">Banner & Ads</span> <span class="caret">▾</span></div>
+            <ul class="submenu" aria-label="Banner & Ads">
+              <li>Banner Category</li>
+              <li>Banner & Ads</li>
+            </ul>
+          </li>
+          <li>📈 <span class="txt">Reports</span></li>
       </ul>
     </aside>
 


### PR DESCRIPTION
## Summary
- add Banner & Ads dropdown with Banner Category and Banner & Ads links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689cb4a90fa483279626d39d6b14833f