### PR TITLE
Add reports submenu to sidebar

### DIFF
--- a/ecommerce.html
+++ b/ecommerce.html
@@ -170,7 +170,14 @@
         <li>🔗 <span class="txt">API Integration</span></li>
         <li>📊 <span class="txt">G. Pixel & GTM</span></li>
         <li>🖼️ <span class="txt">Banner & Ads</span></li>
-        <li>📈 <span class="txt">Reports</span></li>
+        <li class="has-sub">
+          <div class="menu-head">📈 <span class="txt">Reports</span> <span class="caret">▾</span></div>
+          <ul class="submenu" aria-label="Reports">
+            <li>Stock Report</li>
+            <li>IP Block</li>
+            <li>Order Reports</li>
+          </ul>
+        </li>
       </ul>
     </aside>
 


### PR DESCRIPTION
## Summary
- add expandable Reports menu with Stock Report, IP Block, and Order Reports links

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689cb4bb41a483278d5ac9df5525ebe7