### PR TITLE
feat: add site setting submenu

### DIFF
--- a/ecommerce.html
+++ b/ecommerce.html
@@ -181,7 +181,18 @@
             <li>Customers</li>
           </ul>
         </li>
-        <li>⚙️ <span class="txt">Site Settings</span></li>
+        <li class="has-sub">
+          <div class="menu-head">⚙️ <span class="txt">Site Setting</span> <span class="caret">▾</span></div>
+          <ul class="submenu" aria-label="Site Setting">
+            <li>General Setting</li>
+            <li>Pixels Setting</li>
+            <li>Social Media</li>
+            <li>Contact</li>
+            <li>Create Page</li>
+            <li>Shipping Charge</li>
+            <li>Order Status</li>
+          </ul>
+        </li>
         <li>🔗 <span class="txt">API Integration</span></li>
         <li>📊 <span class="txt">G. Pixel & GTM</span></li>
         <li>🖼️ <span class="txt">Banner & Ads</span></li>


### PR DESCRIPTION
## Summary
- add nested site setting menu with general, pixels, and other options
- retain existing users submenu

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689cb66d4bc08327aacbf38a6c85a83b