### PR TITLE
Add reports submenu to dashboard

### DIFF
--- a/ecommerce.html
+++ b/ecommerce.html
@@ -183,15 +183,22 @@
         </li>
         <li>⚙️ <span class="txt">Site Settings</span></li>
         <li>🔗 <span class="txt">API Integration</span></li>
-          <li>📊 <span class="txt">G. Pixel & GTM</span></li>
-          <li class="has-sub">
-            <div class="menu-head">🖼️ <span class="txt">Banner & Ads</span> <span class="caret">▾</span></div>
-            <ul class="submenu" aria-label="Banner & Ads">
-              <li>Banner Category</li>
-              <li>Banner & Ads</li>
-            </ul>
-          </li>
-          <li>📈 <span class="txt">Reports</span></li>
+        <li>📊 <span class="txt">G. Pixel & GTM</span></li>
+        <li class="has-sub">
+          <div class="menu-head">🖼️ <span class="txt">Banner & Ads</span> <span class="caret">▾</span></div>
+          <ul class="submenu" aria-label="Banner & Ads">
+            <li>Banner Category</li>
+            <li>Banner & Ads</li>
+          </ul>
+        </li>
+        <li class="has-sub">
+          <div class="menu-head">📈 <span class="txt">Reports</span> <span class="caret">▾</span></div>
+          <ul class="submenu" aria-label="Reports">
+            <li>Stock Report</li>
+            <li>IP Block</li>
+            <li>Order Reports</li>
+          </ul>
+        </li>
       </ul>
     </aside>
 


### PR DESCRIPTION
## Summary
- add Banner & Ads nested menu
- introduce Reports dropdown with Stock Report, IP Block, and Order Reports links

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689cb6b7804483278eed99c50b89579b