### PR TITLE
feat: add tag manager submenu

### DIFF
--- a/ecommerce.html
+++ b/ecommerce.html
@@ -212,7 +212,13 @@
           </ul>
         </li>
         <li>🔗 <span class="txt">API Integration</span></li>
-        <li>📊 <span class="txt">G. Pixel & GTM</span></li>
+        <li class="has-sub">
+          <div class="menu-head">📊 <span class="txt">G. Pixel & GTM</span> <span class="caret">▾</span></div>
+          <ul class="submenu" aria-label="Tag Manager">
+            <li>Tag Manager</li>
+            <li>Pixel Manage</li>
+          </ul>
+        </li>
         <li class="has-sub">
           <div class="menu-head">🖼️ <span class="txt">Banner & Ads</span> <span class="caret">▾</span></div>
           <ul class="submenu" aria-label="Banner & Ads">


### PR DESCRIPTION
## Summary
- add collapsible submenu for Google Pixel and GTM

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689cb8ec88b88327b59522db50c2a903