### PR TITLE
Add API integration submenu

### DIFF
--- a/ecommerce.html
+++ b/ecommerce.html
@@ -167,7 +167,14 @@
         <li>📄 <span class="txt">Landing Page</span></li>
         <li>👥 <span class="txt">Users</span></li>
         <li>⚙️ <span class="txt">Site Settings</span></li>
-        <li>🔗 <span class="txt">API Integration</span></li>
+        <li class="has-sub">
+  <div class="menu-head">🔗 <span class="txt">API Integration</span> <span class="caret">▾</span></div>
+  <ul class="submenu" aria-label="API Integration">
+    <li>Payment Gateway</li>
+    <li>SMS Gateway</li>
+    <li>Courier API</li>
+  </ul>
+</li>
         <li>📊 <span class="txt">G. Pixel & GTM</span></li>
         <li>🖼️ <span class="txt">Banner & Ads</span></li>
         <li>📈 <span class="txt">Reports</span></li>


### PR DESCRIPTION
## Summary
- Add expandable "API Integration" menu with Payment Gateway, SMS Gateway, and Courier API options

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689cb493fa4c8327842a545ca84f96b1