### PR TITLE
fix: enable orders dropdown

### DIFF
--- a/ecommerce.html
+++ b/ecommerce.html
@@ -414,12 +414,15 @@
       pageTitle.textContent = 'All Orders (' + visible + ')';
     }
 
-    document.querySelectorAll('.menu .has-sub .menu-head').forEach(head => {
-      head.addEventListener('click', () => {
+    const menu = document.querySelector('.menu');
+    if (menu) {
+      menu.addEventListener('click', (e) => {
+        const head = e.target.closest('.menu-head');
+        if (!head) return;
         const li = head.closest('.has-sub');
-        li.classList.toggle('open');
+        if (li) li.classList.toggle('open');
       });
-    });
+    }
     searchBtn.addEventListener('click', applyFilters);
     searchInput.addEventListener('input', applyFilters);
 


### PR DESCRIPTION
## Summary
- handle sidebar submenu clicks with event delegation for reliable toggle behavior

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689cc5e26d3883278606e0f90aca85ff